### PR TITLE
Replace chai with invariant

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.translateBlueprintsWith = exports.translateBlueprintTypesWith = exports.createBlueprint = undefined;
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var _chai = require('chai');
+var _invariant = require('invariant');
+
+var _invariant2 = _interopRequireDefault(_invariant);
 
 var _reduxActions = require('redux-actions');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
  * Creates an action blueprint. Allows delayed assignment of action type which is useful for library designers requiring namespaced action types.
@@ -23,12 +27,12 @@ var _reduxActions = require('redux-actions');
  * @return {Function}                An action blueprint function that accepts an action type creator function as param to return an action creator.
  */
 var createBlueprint = exports.createBlueprint = function createBlueprint(blueprintType) {
-  var payloadCreator = arguments.length <= 1 || arguments[1] === undefined ? function (args) {
+  var payloadCreator = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function (args) {
     return args;
-  } : arguments[1];
-  var metaCreator = arguments.length <= 2 || arguments[2] === undefined ? function (args) {
+  };
+  var metaCreator = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function (args) {
     return args;
-  } : arguments[2];
+  };
   return function (translateBlueprintType) {
     return (0, _reduxActions.createAction)(translateBlueprintType(blueprintType), function (args) {
       return payloadCreator(args);
@@ -45,11 +49,11 @@ var createBlueprint = exports.createBlueprint = function createBlueprint(bluepri
  */
 var translateBlueprintTypesWith = exports.translateBlueprintTypesWith = function translateBlueprintTypesWith(translateBlueprintType) {
   return function (blueprintTypes) {
-    _chai.assert.ok(blueprintTypes, 'blueprint types are required');
+    (0, _invariant2.default)(blueprintTypes, 'blueprint types are required');
     if (Array.isArray(blueprintTypes)) return blueprintTypes.map(function (x) {
       return translateBlueprintType(x);
     });
-    (0, _chai.assert)((typeof blueprintTypes === 'undefined' ? 'undefined' : _typeof(blueprintTypes)) === 'object', 'blueprint types must be array or object');
+    (0, _invariant2.default)((typeof blueprintTypes === 'undefined' ? 'undefined' : _typeof(blueprintTypes)) === 'object', 'blueprint types must be array or object');
     return Object.keys(blueprintTypes).reduce(function (actionTypes, x) {
       actionTypes[x] = translateBlueprintType(blueprintTypes[x]);
       return actionTypes;
@@ -71,11 +75,11 @@ var translateBlueprintTypesWith = exports.translateBlueprintTypesWith = function
  */
 var translateBlueprintsWith = exports.translateBlueprintsWith = function translateBlueprintsWith(translateBlueprintType) {
   return function (blueprints) {
-    _chai.assert.ok(blueprints, 'blueprints are required');
+    (0, _invariant2.default)(blueprints, 'blueprints are required');
     if (Array.isArray(blueprints)) return blueprints.map(function (x) {
       return blueprint(translateBlueprintType);
     });
-    (0, _chai.assert)((typeof blueprints === 'undefined' ? 'undefined' : _typeof(blueprints)) === 'object', 'blueprints must be array or object');
+    (0, _invariant2.default)((typeof blueprints === 'undefined' ? 'undefined' : _typeof(blueprints)) === 'object', 'blueprints must be array or object');
     return Object.keys(blueprints).reduce(function (actionCreators, x) {
       actionCreators[x] = blueprints[x](translateBlueprintType);
       return actionCreators;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "homepage": "https://cchamberlain.github.io/redux-blueprint",
   "dependencies": {
-    "chai": "^3.5.0",
+    "invariant": "^2.2.2",
     "redux-actions": "^0.9.1"
   }
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai'
+import invariant from 'invariant'
 import { createAction } from 'redux-actions'
 
 /**
@@ -24,10 +24,10 @@ export const createBlueprint = (blueprintType, payloadCreator = args => args, me
  * @return {blueprintTypeTranslator}          Function that accepts array or object of blueprint type values and returns action types.
  */
 export const translateBlueprintTypesWith = translateBlueprintType => blueprintTypes => {
-  assert.ok(blueprintTypes, 'blueprint types are required')
+  invariant(blueprintTypes, 'blueprint types are required')
   if(Array.isArray(blueprintTypes))
     return blueprintTypes.map(x => translateBlueprintType(x))
-  assert(typeof blueprintTypes === 'object', 'blueprint types must be array or object')
+  invariant(typeof blueprintTypes === 'object', 'blueprint types must be array or object')
   return Object.keys(blueprintTypes).reduce((actionTypes, x) => {
     actionTypes[x] = translateBlueprintType(blueprintTypes[x])
     return actionTypes
@@ -48,10 +48,10 @@ export const translateBlueprintTypesWith = translateBlueprintType => blueprintTy
  * @return {blueprintTranslator}              Function that accepts array or object of blueprint values and returns redux-actions FSA actionCreators.
  */
 export const translateBlueprintsWith = translateBlueprintType => blueprints => {
-  assert.ok(blueprints, 'blueprints are required')
+  invariant(blueprints, 'blueprints are required')
   if(Array.isArray(blueprints))
     return blueprints.map(x => blueprint(translateBlueprintType))
-  assert(typeof blueprints === 'object', 'blueprints must be array or object')
+  invariant(typeof blueprints === 'object', 'blueprints must be array or object')
   return Object.keys(blueprints).reduce((actionCreators, x) => {
     actionCreators[x] = blueprints[x](translateBlueprintType)
     return actionCreators


### PR DESCRIPTION
Since https://github.com/noderaider/redux-idle-monitor has a dependency on this, `chai` was still being added to any apps that have it as a dependency. This just replaces the `assert` calls with `invariant`.